### PR TITLE
Adding enum write mode to the libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,19 @@ Fork from http://code.google.com/p/protobuf-java-format/
 
 ## Description
 
-Provide serialization and de-serialization of different formats based on Google’s protobuf Message. Enables overriding the default (byte array) output to text based formats such as XML, JSON and HTML.
+This fork adds control on how the protobuf enums are encoded. The original code is able to decode enums by either their name or their integer value depending on what is found in the encoded stream.
+It always and only encoded the enum values by name though: with this version it's possible to control that behaviour by an option provided by a (new) builder.
 
 ##Example
-For XML output, use XmlFormat
+ProtobufFormatter jsonFormat =
+            new FormatFactory()
+                    .createFormatter(FormatFactory.Formatter.JSON)
+                    .withEnumWriteMode(EnumWriteMode.NAME)            // This is the default behaviour
+                    .build();
+                    
+ProtobufFormatter jsonFormat =
+            new FormatFactory()
+                    .createFormatter(FormatFactory.Formatter.JSON)
+                    .withEnumWriteMode(EnumWriteMode.NUMBER)          // This is the new behaviour
+                    .build();
 
-```java
-Message someProto = SomeProto.getDefaultInstance();
-String xmlFormat = XmlFormat.printToString(someProto);
-```
-
-For XML input, use XmlFormat
-```java
-Message.Builder builder = SomeProto.newBuilder();
-String xmlFormat = _load xml document from a source_;
-XmlFormat.merge(xmlFormat, builder);
-```
-
-For Json output, use JsonFormat
-```java
-Message someProto = SomeProto.getDefaultInstance();
-String jsonFormat = JsonFormat.printToString(someProto);
-```
-
-For Json input, use JsonFormat
-```java
-Message.Builder builder = SomeProto.newBuilder();
-String jsonFormat = _load json document from a source_;
-JsonFormat.merge(jsonFormat, builder);
-```
-
-For HTML output, use HtmlFormat
-```java
-Message someProto = SomeProto.getDefaultInstance();
-String htmlFormat = HtmlFormat.printToString(someProto);
-```

--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ Fork from http://code.google.com/p/protobuf-java-format/
 This fork adds control on how the protobuf enums are encoded. The original code is able to decode enums by either their name or their integer value depending on what is found in the encoded stream.
 It always and only encoded the enum values by name though: with this version it's possible to control that behaviour by an option provided by a (new) builder.
 
-##Example
+##Example named enum value encoding
+
 ProtobufFormatter jsonFormat =
             new FormatFactory()
                     .createFormatter(FormatFactory.Formatter.JSON)
-                    .withEnumWriteMode(EnumWriteMode.NAME)            // This is the default behaviour
+                    .withEnumWriteMode(EnumWriteMode.NAME)
                     .build();
+
+
+##Example integer enum value encoding
                     
 ProtobufFormatter jsonFormat =
             new FormatFactory()
                     .createFormatter(FormatFactory.Formatter.JSON)
-                    .withEnumWriteMode(EnumWriteMode.NUMBER)          // This is the new behaviour
+                    .withEnumWriteMode(EnumWriteMode.NUMBER)
                     .build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
 		<artifactId>oss-parent</artifactId>
 		<version>7</version>
 	</parent>
-	<groupId>com.googlecode.protobuf-java-format</groupId>
+	<groupId>com.adhslx.lib.commons</groupId>
 	<artifactId>protobuf-java-format</artifactId>
 	<name>protobuf-java-format</name>
-	<version>1.5-SNAPSHOT</version>
+	<version>1.5.1-SNAPSHOT</version>
 	<description>Provide serialization and de-serialization of different formats based on Google’s protobuf Message. Enables overriding the default (byte array) output to text based formats such as XML, JSON and HTML.</description>
 	<url>https://github.com/bivas/protobuf-java-format</url>
 	<packaging>jar</packaging>
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>2.5.0</version>
+			<version>2.6.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/googlecode/protobuf/format/AbstractCharBasedFormatter.java
+++ b/src/main/java/com/googlecode/protobuf/format/AbstractCharBasedFormatter.java
@@ -8,22 +8,20 @@
 
 package com.googlecode.protobuf.format;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import com.google.protobuf.Message.Builder;
 import com.google.protobuf.UnknownFieldSet;
-import com.googlecode.protobuf.format.ProtobufFormatter.ParseException;
 import com.googlecode.protobuf.format.util.TextUtils;
 
+import java.io.*;
+import java.nio.charset.Charset;
+
 public abstract class AbstractCharBasedFormatter extends ProtobufFormatter {
+
+	public AbstractCharBasedFormatter(EnumWriteMode enumWriteMode) {
+		super(enumWriteMode);
+	}
 
 	@Override
 	public void print(Message message, OutputStream output, Charset cs)

--- a/src/main/java/com/googlecode/protobuf/format/CouchDBFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/CouchDBFormat.java
@@ -1,11 +1,11 @@
 package com.googlecode.protobuf.format;
 
 
-import java.io.IOException;
-
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
+
+import java.io.IOException;
 
 /**
  * Created by IntelliJ IDEA.
@@ -15,6 +15,10 @@ import com.google.protobuf.UnknownFieldSet;
  * To change this template use File | Settings | File Templates.
  */
 public class CouchDBFormat extends JsonFormat {
+
+    public CouchDBFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
 
     /**
      * Outputs a textual representation of the Protocol Message supplied into the parameter output.

--- a/src/main/java/com/googlecode/protobuf/format/EnumWriteMode.java
+++ b/src/main/java/com/googlecode/protobuf/format/EnumWriteMode.java
@@ -1,0 +1,5 @@
+package com.googlecode.protobuf.format;
+
+public enum EnumWriteMode {
+    NAME, NUMBER
+}

--- a/src/main/java/com/googlecode/protobuf/format/FormatFactory.java
+++ b/src/main/java/com/googlecode/protobuf/format/FormatFactory.java
@@ -8,6 +8,8 @@
 
 package com.googlecode.protobuf.format;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class FormatFactory {
 	
 	public FormatFactory() {}
@@ -31,14 +33,36 @@ public class FormatFactory {
 		}
 	}
 	
-	
-	public ProtobufFormatter createFormatter(Formatter formatter) {
-		try {
-			return formatter.getFormatterClass().newInstance();
-		} catch (InstantiationException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException(e);
+
+	public static class ProtobufFormatterBuilder {
+		private final Formatter formatter;
+		private EnumWriteMode enumWriteMode = EnumWriteMode.NAME;
+
+		public ProtobufFormatterBuilder(Formatter formatter) {
+			this.formatter = formatter;
 		}
+
+		public ProtobufFormatterBuilder withEnumWriteMode(EnumWriteMode enumWriteMode) {
+			this.enumWriteMode = enumWriteMode;
+			return this;
+		}
+
+		public ProtobufFormatter build() {
+			try {
+				return formatter.getFormatterClass().getConstructor(EnumWriteMode.class).newInstance(enumWriteMode);
+			} catch (InstantiationException e) {
+				throw new RuntimeException(e);
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException(e);
+			} catch (NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			} catch (InvocationTargetException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	public ProtobufFormatterBuilder createFormatter(Formatter formatter) {
+		return new ProtobufFormatterBuilder(formatter);
 	}
 }

--- a/src/main/java/com/googlecode/protobuf/format/HtmlFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/HtmlFormat.java
@@ -60,7 +60,11 @@ public final class HtmlFormat extends AbstractCharBasedFormatter {
     private static final String FIELD_NAME_STYLE = "font-weight: bold; color: #669966;font-size: 14px; font-family: sans-serif;";
     private static final String FIELD_VALUE_STYLE = "color: #3300FF;font-size: 13px; font-family: sans-serif;";
 
-    
+    public HtmlFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
+
+
     public void print(final Message message, Appendable output) throws IOException {
     	HtmlGenerator generator = new HtmlGenerator(output);
         printTitle(message, generator);
@@ -206,7 +210,14 @@ public final class HtmlFormat extends AbstractCharBasedFormatter {
             }
 
             case ENUM: {
-                generator.print(((EnumValueDescriptor) value).getName());
+                switch (enumWriteMode) {
+                    case NAME:
+                        generator.print(((EnumValueDescriptor) value).getName());
+                        break;
+                    case NUMBER:
+                        generator.print(unsignedToString(((EnumValueDescriptor) value).getNumber()));
+                        break;
+                }
                 break;
             }
 

--- a/src/main/java/com/googlecode/protobuf/format/JavaPropsFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JavaPropsFormat.java
@@ -1,17 +1,13 @@
 package com.googlecode.protobuf.format;
 
+import com.google.protobuf.*;
+
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.CharBuffer;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.Message;
-import com.google.protobuf.UnknownFieldSet;
 import static com.googlecode.protobuf.format.util.TextUtils.*;
 
 /**
@@ -28,7 +24,11 @@ import static com.googlecode.protobuf.format.util.TextUtils.*;
  */
 public class JavaPropsFormat extends AbstractCharBasedFormatter {
 
-	/**
+    public JavaPropsFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
+
+    /**
 	 * Outputs a textual representation of the Protocol Message supplied into
 	 * the parameter output. (This representation is the new version of the
 	 * classic "ProtocolPrinter" output from the original Protocol Buffer system)
@@ -192,7 +192,14 @@ public class JavaPropsFormat extends AbstractCharBasedFormatter {
         break;
 
       case ENUM:
-        generator.print(((Descriptors.EnumValueDescriptor) value).getName());
+          switch (enumWriteMode) {
+              case NAME:
+                  generator.print(((Descriptors.EnumValueDescriptor) value).getName());
+                  break;
+              case NUMBER:
+                  generator.print(unsignedToString(((Descriptors.EnumValueDescriptor) value).getNumber()));
+                  break;
+          }
         break;
 
       case MESSAGE:

--- a/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
@@ -69,6 +69,10 @@ import static com.googlecode.protobuf.format.util.TextUtils.*;
  */
 public class JsonFormat extends AbstractCharBasedFormatter {
 
+    public JsonFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
+
     /**
      * Outputs a textual representation of the Protocol Message supplied into the parameter output.
      * (This representation is the new version of the classic "ProtocolPrinter" output from the
@@ -196,19 +200,24 @@ public class JsonFormat extends AbstractCharBasedFormatter {
                 generator.print("\"");
                 break;
 
-            case BYTES: {
+            case BYTES:
                 generator.print("\"");
                 generator.print(escapeBytes((ByteString) value));
                 generator.print("\"");
                 break;
-            }
 
-            case ENUM: {
-                generator.print("\"");
-                generator.print(((EnumValueDescriptor) value).getName());
-                generator.print("\"");
+            case ENUM:
+                switch (enumWriteMode) {
+                    case NAME:
+                        generator.print("\"");
+                        generator.print(((EnumValueDescriptor) value).getName());
+                        generator.print("\"");
+                        break;
+                    case NUMBER:
+                        generator.print(unsignedToString(((EnumValueDescriptor) value).getNumber()));
+                        break;
+                }
                 break;
-            }
 
             case MESSAGE:
             case GROUP:

--- a/src/main/java/com/googlecode/protobuf/format/ProtobufFormatter.java
+++ b/src/main/java/com/googlecode/protobuf/format/ProtobufFormatter.java
@@ -17,12 +17,16 @@ import java.nio.charset.Charset;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
-import com.googlecode.protobuf.format.JavaPropsFormat.ParseException;
 
 public abstract class ProtobufFormatter {
     private Charset defaultCharset = Charset.defaultCharset();
+	protected final EnumWriteMode enumWriteMode;
 
-    /**
+	protected ProtobufFormatter(EnumWriteMode enumWriteMode) {
+		this.enumWriteMode = enumWriteMode;
+	}
+
+	/**
      * Set the default character set to use for input / output data streams
      * @param cs the character set to use by default, when unspecified
      */

--- a/src/main/java/com/googlecode/protobuf/format/SmileFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/SmileFormat.java
@@ -29,17 +29,17 @@ package com.googlecode.protobuf.format;
 */
 
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.Charset;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileParser;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 /**
  * Provide ascii text parsing and formatting support for proto2 instances. The implementation
@@ -57,7 +57,11 @@ import com.google.protobuf.Message;
 public class SmileFormat extends JsonJacksonFormat {
     private static SmileFactory smileFactory = new SmileFactory();
 
-    /**
+	public SmileFormat(EnumWriteMode enumWriteMode) {
+		super(enumWriteMode);
+	}
+
+	/**
      * Parse a text-format message from {@code input} and merge the contents into {@code builder}.
      * Extensions will be recognized if they are registered in {@code extensionRegistry}.
      * @throws IOException 

--- a/src/main/java/com/googlecode/protobuf/format/XmlFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/XmlFormat.java
@@ -29,6 +29,10 @@ package com.googlecode.protobuf.format;
 */
 
 
+import com.google.protobuf.*;
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
@@ -36,15 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.nio.CharBuffer;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.Message;
-import com.google.protobuf.UnknownFieldSet;
-import com.google.protobuf.Descriptors.EnumValueDescriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import static com.googlecode.protobuf.format.util.TextUtils.*;
 
 /**
@@ -61,6 +57,10 @@ import static com.googlecode.protobuf.format.util.TextUtils.*;
  * @author kenton@google.com Kenton Varda
  */
 public final class XmlFormat extends AbstractCharBasedFormatter {
+
+    public XmlFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
 
     /**
      * Outputs a textual representation of the Protocol Message supplied into the parameter output.
@@ -181,15 +181,20 @@ public final class XmlFormat extends AbstractCharBasedFormatter {
                 generator.print(escapeText((String) value));
                 break;
 
-            case BYTES: {
+            case BYTES:
                 generator.print(escapeBytes((ByteString) value));
                 break;
-            }
 
-            case ENUM: {
-                generator.print(((EnumValueDescriptor) value).getName());
+            case ENUM:
+                switch (enumWriteMode) {
+                    case NAME:
+                        generator.print(((EnumValueDescriptor) value).getName());
+                        break;
+                    case NUMBER:
+                        generator.print(unsignedToString(((EnumValueDescriptor) value).getNumber()));
+                        break;
+                }
                 break;
-            }
 
             case MESSAGE:
             case GROUP:

--- a/src/main/java/com/googlecode/protobuf/format/XmlJavaxFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/XmlJavaxFormat.java
@@ -28,8 +28,18 @@ package com.googlecode.protobuf.format;
 */
 
 
-import static com.googlecode.protobuf.format.util.TextUtils.*;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.EnumDescriptor;
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Message;
+import com.google.protobuf.UnknownFieldSet;
 
+import javax.xml.namespace.QName;
+import javax.xml.stream.*;
+import javax.xml.stream.events.XMLEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -39,22 +49,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-import javax.xml.stream.events.XMLEvent;
-
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors.Descriptor;
-import com.google.protobuf.Descriptors.EnumDescriptor;
-import com.google.protobuf.Descriptors.EnumValueDescriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.Message;
-import com.google.protobuf.UnknownFieldSet;
+import static com.googlecode.protobuf.format.util.TextUtils.*;
 
 /**
  * <p>
@@ -77,8 +72,12 @@ public class XmlJavaxFormat extends ProtobufFormatter {
     
     private XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
     private XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
-	
-		
+
+    public XmlJavaxFormat(EnumWriteMode enumWriteMode) {
+        super(enumWriteMode);
+    }
+
+
     /**
      * Outputs a Smile representation of the Protocol Message supplied into the parameter output.
      * (This representation is the new version of the classic "ProtocolPrinter" output from the
@@ -286,6 +285,14 @@ public class XmlJavaxFormat extends ProtobufFormatter {
             }
 
             case ENUM: {
+                switch (enumWriteMode) {
+                    case NAME:
+                        generator.writeCharacters(((EnumValueDescriptor) value).getName());
+                        break;
+                    case NUMBER:
+                        generator.writeCharacters(Integer.toString(((EnumValueDescriptor) value).getNumber()));
+                        break;
+                }
             	generator.writeCharacters(((EnumValueDescriptor) value).getName());
                 break;
             }

--- a/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
@@ -20,7 +20,7 @@ public class JsonFormatTest {
     private static final String RESOURCE_PATH = "/expectations/JsonFormatTest/";
     private static final FormatFactory FORMAT_FACTORY = new FormatFactory();
     private static final ProtobufFormatter JSON_FORMATTER =
-            FORMAT_FACTORY.createFormatter(FormatFactory.Formatter.JSON);
+            FORMAT_FACTORY.createFormatter(FormatFactory.Formatter.JSON).build();
 
     private static String getExpected(String name) throws IOException {
         return Files.readFile(JsonFormatTest.class.getResourceAsStream(RESOURCE_PATH + "test1.json")).trim();

--- a/src/test/java/com/googlecode/protobuf/format/JsonJacksonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonJacksonFormatTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.google.protobuf.ExtensionRegistry;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
 import protobuf_unittest.UnittestProto;
@@ -15,7 +14,6 @@ import java.math.BigInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.testng.Assert.*;
 
 /**
  * @author scr on 10/13/15.
@@ -30,7 +28,7 @@ public class JsonJacksonFormatTest {
         JsonGenerator jsonGenerator = JSON_FACTORY.createGenerator(writer)
                 .setPrettyPrinter(new DefaultPrettyPrinter());
         JsonJacksonFormat jsonJacksonFormat =
-                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON);
+                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON).build();
         jsonJacksonFormat.print(UnittestProto.TestAllTypes.newBuilder()
                 .setOptionalForeignEnum(UnittestProto.ForeignEnum.FOREIGN_BAR)
                 .setOptionalFloat(0)
@@ -45,7 +43,7 @@ public class JsonJacksonFormatTest {
         StringWriter writer = new StringWriter();
         JsonGenerator jsonGenerator = JSON_FACTORY.createGenerator(writer);
         JsonJacksonFormat jsonJacksonFormat =
-                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON);
+                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON).build();
         final long maxIntAsLong = ((long) Integer.MAX_VALUE) << 1;
         final BigInteger maxLongAsBigInt = BigInteger.valueOf(Long.MAX_VALUE).shiftLeft(1);
         jsonJacksonFormat.print(UnittestProto.TestAllTypes.newBuilder()


### PR DESCRIPTION
Hello there,
I really appreciated this library. Protobuf util is still not mature at this time (generates beautified json code, and there's no way to avoid that).
This library was lacking one thing that we really needed, though: encoding the enums as integers.
I had a look at your library and I saw that it's capable of reading the enums back by integer encoding, but it was always outputting them as strings.
This fork addresses that by adding a builder for the library that accepts the enum writing mode as a parameter.
