### PR TITLE
fixed an exception which is thrown in case of facing null instead of an object in json

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
@@ -1022,6 +1022,10 @@ public class JsonFormat extends AbstractCharBasedFormatter {
                                        ExtensionRegistry.ExtensionInfo extension,
                                        boolean unknown) throws ParseException {
 
+        if ("null".equals(tokenizer.currentToken())) {
+            tokenizer.consume("null");
+            return null;
+        }
         Message.Builder subBuilder;
         if (extension == null) {
             subBuilder = builder.newBuilderForField(field);


### PR DESCRIPTION
## Issue #20

```
{
  "object" : null 
}
```

Json parser ins't able to parse smth like that.
