### PR TITLE
Correctly slurp unknown fields into message that are unknown at both serialization and deserialization time

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
@@ -31,6 +31,8 @@ package com.googlecode.protobuf.format;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
@@ -42,6 +44,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -515,6 +518,8 @@ public class JsonFormat extends AbstractCharBasedFormatter {
 
             return ("true".equals(currentToken) || "false".equals(currentToken));
         }
+        
+        
 
         /**
          * @return currentToken to which the Tokenizer is pointing.
@@ -618,7 +623,7 @@ public class JsonFormat extends AbstractCharBasedFormatter {
                 return Double.NaN;
             }
             try {
-                double result = Double.parseDouble(prepareNumberFromString(currentToken));
+                double result = parseDoubleOrFixed64(prepareNumberFromString(currentToken));
                 nextToken();
                 return result;
             } catch (NumberFormatException e) {
@@ -643,7 +648,7 @@ public class JsonFormat extends AbstractCharBasedFormatter {
                 return Float.NaN;
             }
             try {
-                float result = Float.parseFloat(prepareNumberFromString(currentToken));
+                float result = parseFloatOrFixed32(prepareNumberFromString(currentToken));
                 nextToken();
                 return result;
             } catch (NumberFormatException e) {
@@ -839,15 +844,19 @@ public class JsonFormat extends AbstractCharBasedFormatter {
 
         // Last try to lookup by field-index if 'name' is numeric,
         // which indicates a possible unknown field
-        if (field == null && TextUtils.isDigits(name)) {
-            int fieldNumber = Integer.parseInt(name);
-        	field = type.findFieldByNumber(fieldNumber);
-            if (field != null) {
-            	unknownInJSONOnly = true;
-            } else {
-            	unknownInBothJSONAndProto = true;
-            	handleUnknownField(tokenizer, builder, fieldNumber);
-            }
+        if (field == null) {
+            try {
+	        	int fieldNumber = Integer.parseInt(name);
+	        	field = type.findFieldByNumber(fieldNumber);
+	            if (field != null) {
+	            	unknownInJSONOnly = true;
+	            } else {
+	            	unknownInBothJSONAndProto = true;
+	            	UnknownFieldSet.Builder unknownBuilder = builder.getUnknownFields().toBuilder();
+	            	handleUnknownField(tokenizer, fieldNumber, unknownBuilder);        		
+	        		builder.setUnknownFields(unknownBuilder.build());
+	            }
+            } catch (NumberFormatException e) {} // not an integer, skip
         }
 
         // Finally, look for extensions
@@ -886,33 +895,64 @@ public class JsonFormat extends AbstractCharBasedFormatter {
         }
     }
     
-    private void handleUnknownField(Tokenizer tokenizer,    										
-    		Message.Builder builder,
-    		int fieldNumber) throws ParseException {    	
+    private void handleUnknownField(Tokenizer tokenizer,
+    		int fieldNumber,
+    		UnknownFieldSet.Builder fieldSetBuilder) throws ParseException {    	
     	tokenizer.tryConsume(":");
-    	if ("{".equals(tokenizer.currentToken())) {
-    		// Message structure
-    		tokenizer.consume("{");
+    	String currentToken = tokenizer.currentToken();
+    	if (tokenizer.tryConsume("{")) {
+    		// Group structure
+    		
+    		UnknownFieldSet.Builder groupBuilder = UnknownFieldSet.newBuilder();
     		do {
-    			tokenizer.consumeIdentifier();
-    			handleUnknownField(tokenizer, builder, fieldNumber);
+    			String name = tokenizer.consumeIdentifier();
+    			if (TextUtils.isDigits(name)) {
+    				int innerFieldNumber = Integer.parseInt(name);    				
+    				handleUnknownField(tokenizer, innerFieldNumber, groupBuilder);    				
+    			} else {
+    				throw new ParseException("Non-numberic field name found in unknown group");
+    			}    			
     		} while (tokenizer.tryConsume(","));
+    		fieldSetBuilder.mergeField(
+					fieldNumber, 
+					UnknownFieldSet.Field
+						.newBuilder()
+						.addGroup(groupBuilder.build()).build());
     		tokenizer.consume("}");
-    	} else if ("[".equals(tokenizer.currentToken())) {
-    		// Collection
-    		tokenizer.consume("[");
+    	} else if (tokenizer.tryConsume("[")) {
+    		// Collection    		
     		do {
-    			handleUnknownField(tokenizer, builder, fieldNumber);
+    			handleUnknownField(tokenizer, fieldNumber, fieldSetBuilder);
     		} while (tokenizer.tryConsume(","));
     		tokenizer.consume("]");
-    	} else {
-    		ByteString data = tokenizer.consumeByteString();
-    		UnknownFieldSet.Builder unknownBuilder = builder.getUnknownFields().toBuilder();
-    		unknownBuilder.addField(fieldNumber, UnknownFieldSet.Field
+    	} else if (currentToken.length() > 0 && currentToken.startsWith("\"")) {
+    		ByteString data = tokenizer.consumeByteString();    		
+    		fieldSetBuilder.mergeField(fieldNumber, UnknownFieldSet.Field
     				.newBuilder()
     				.addLengthDelimited(data)
-    				.build());
-    		builder.setUnknownFields(unknownBuilder.build());	 
+    				.build());	 
+    	} else {
+    		// Must be varint, fixed32 or fixed64
+    		if (is32BitHex(currentToken)) {
+    			int fixed32 = tokenizer.consumeInt32();
+    			fieldSetBuilder.mergeField(fieldNumber, UnknownFieldSet.Field
+        				.newBuilder()
+        				.addFixed32(fixed32)
+        				.build());
+    		} else if (is64BitHex(currentToken)) {
+    			long fixed64 = tokenizer.consumeInt64();
+    			fieldSetBuilder.mergeField(fieldNumber, UnknownFieldSet.Field
+        				.newBuilder()
+        				.addFixed64(fixed64)
+        				.build());
+    		} else {
+    			// must be varint
+    			long varint = tokenizer.consumeInt64();
+    			fieldSetBuilder.mergeField(fieldNumber, UnknownFieldSet.Field
+        				.newBuilder()
+        				.addVarint(varint)
+        				.build());
+    		}
     	}
     }
 
@@ -1069,7 +1109,7 @@ public class JsonFormat extends AbstractCharBasedFormatter {
             subBuilder = extension.defaultInstance.newBuilderForType();
         }
 
-        if (unknown) {
+        if (unknown && field.getType() != Type.GROUP) {
             ByteString data = tokenizer.consumeByteString();
             try {
                 subBuilder.mergeFrom(data);
@@ -1245,8 +1285,8 @@ public class JsonFormat extends AbstractCharBasedFormatter {
                                 break;
                             case 'u':
                                 // UTF8 escape
-                                code = (16 * 3 * digitValue(input.charAt(i+1))) +
-                                        (16 * 2 * digitValue(input.charAt(i+2))) +
+                                code = (16 * 16 * 16 * digitValue(input.charAt(i+1))) +
+                                        (16 * 16 * digitValue(input.charAt(i+2))) +
                                         (16 * digitValue(input.charAt(i+3))) +
                                         digitValue(input.charAt(i+4));
                                 i = i+4;
@@ -1549,5 +1589,49 @@ public class JsonFormat extends AbstractCharBasedFormatter {
         }
 
         return numberText;
+    }
+    
+    /**
+     * @return true if input String can be parsed as 32-bit hex
+     */
+    private static boolean is32BitHex(String value) {
+    	return value.matches("0x[0-9a-fA-F]{8}");    	
+    }
+    
+    /**
+     * @return true if input String can be parsed as 64-bit hex
+     */
+    private static boolean is64BitHex(String value) {
+    	return value.matches("0x[0-9a-fA-F]{16}");    	
+    }
+     
+    private static float parseFloatOrFixed32(String value) {    	
+    	try {
+    		return(parseFloat(value));
+    	} catch (NumberFormatException e) {
+    		int intValue = parseInt32(value);    		
+    		ByteBuffer byteBuffer = (ByteBuffer)ByteBuffer
+        			.allocate(Integer.BYTES)
+        			.putInt(intValue)
+        			.order(ByteOrder.BIG_ENDIAN)
+        			.rewind();
+    		float f = byteBuffer.getFloat();
+    		return f;
+    	}
+    }
+    
+    private static double parseDoubleOrFixed64(String value) {
+    	try {
+    		return(parseDouble(value));
+    	} catch (NumberFormatException e) {
+    		long longValue = parseInt64(value);    		
+    		ByteBuffer byteBuffer = (ByteBuffer)ByteBuffer
+        			.allocate(Long.BYTES)
+        			.putLong(longValue)
+        			.order(ByteOrder.BIG_ENDIAN)
+        			.rewind();
+    		double d = byteBuffer.getDouble();
+    		return d;
+    	}
     }
 }

--- a/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
@@ -52,8 +52,7 @@ public class JsonFormatTest {
         assertThat(formatter.printToString(input), is(expectedString));
     }
 
-    // TODO(scr): Re-enable test when the code is fixed to enable slurping unknown fields into the message.
-    @Test(enabled = false, description = "https://github.com/bivas/protobuf-java-format/issues/23")
+    @Test(enabled = true, description = "https://github.com/bivas/protobuf-java-format/issues/23")
     public void testIssue23() throws Exception {
         Issue23.MsgWithUnknownFields issue23Message = Issue23.MsgWithUnknownFields.newBuilder()
                 .setLeaf1("Hello")

--- a/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
@@ -5,9 +5,17 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
 import com.googlecode.protobuf.format.issue23.Issue23;
+import com.googlecode.protobuf.format.issue23.Issue23.InnerTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.InnerTestMessage.InnerInnerTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.NewTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.NewTestMessage.UnknownGroup;
+import com.googlecode.protobuf.format.issue23.Issue23.OldTestMessage;
+
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
+
 import protobuf_unittest.UnittestProto;
 import sun.nio.cs.StandardCharsets;
 
@@ -52,8 +60,8 @@ public class JsonFormatTest {
         assertThat(formatter.printToString(input), is(expectedString));
     }
 
-    @Test(enabled = true, description = "https://github.com/bivas/protobuf-java-format/issues/23")
-    public void testIssue23() throws Exception {
+    @Test(description = "https://github.com/bivas/protobuf-java-format/issues/23")
+    public void testIssue23Simple() throws Exception {
         Issue23.MsgWithUnknownFields issue23Message = Issue23.MsgWithUnknownFields.newBuilder()
                 .setLeaf1("Hello")
                 .setLeaf2(23)
@@ -73,5 +81,78 @@ public class JsonFormatTest {
         Issue23.registerAllExtensions(extensionRegistry);
         JSON_FORMATTER.merge(message, extensionRegistry, issue23Builder);
         assertThat("No unknown field 4", issue23Builder.getUnknownFields().hasField(4));
+    }
+    
+    @Test(description = "https://github.com/bivas/protobuf-java-format/issues/23")
+    public void testIssue23Complex() throws Exception {
+    	// Create version of message with "unknown" fields
+        NewTestMessage expected = NewTestMessage.newBuilder()
+            .setKnownfield("hello")
+            .setUnknownfieldstring1("world")
+            .addUnknownfieldstring2("I")
+            .addUnknownfieldstring2("am")
+            .setUnknownfieldMessage(InnerTestMessage.newBuilder()
+                .setValue(30)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(1.2f))
+            )
+            .setUnknownfieldInt64(51232271120233L)
+            .setUnknownfieldInt32(6)
+            .setUnknownfieldFloat(2.3f)
+            .setUnknownfieldDouble(3.14d)
+            .addUnknownGroup(UnknownGroup.newBuilder()
+                .setName("hi")
+                .setIntvalue(23)
+                .setFloatvalue(5.2f)
+                .setLongvalue(44232993922327L))
+            .addUnknownfieldRepeatedMessage(InnerTestMessage.newBuilder()
+                .setValue(6)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(-1.3f))
+            )
+            .addUnknownfieldRepeatedMessage(InnerTestMessage.newBuilder()
+                .setValue(-110)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(0f))
+            )
+            .build();
+
+        // Parse this message into the old version of the proto
+        OldTestMessage parsedIntoOld = OldTestMessage.parseFrom(expected.toByteArray());
+
+        NewTestMessage newRightBackFromOld = NewTestMessage.parseFrom(parsedIntoOld.toByteArray());
+        Assert.assertEquals(newRightBackFromOld, expected);
+
+        // Convert to json
+        String oldJson = JSON_FORMATTER.printToString(parsedIntoOld);
+
+        // Parse back from json into new and old protos
+        OldTestMessage.Builder oldBuilder = OldTestMessage.newBuilder();
+        JSON_FORMATTER.merge(
+            oldJson,
+            ExtensionRegistry.getEmptyRegistry(),
+            oldBuilder);
+        OldTestMessage oldParsedFromJson = oldBuilder.build();
+        NewTestMessage.Builder newBuilder = NewTestMessage.newBuilder();
+        JSON_FORMATTER.merge(
+            oldJson,
+            ExtensionRegistry.getEmptyRegistry(),
+            newBuilder);
+        NewTestMessage newParsedFromJson = newBuilder.build(); 
+
+        NewTestMessage newParsedFromOld = NewTestMessage.parseFrom(oldParsedFromJson.toByteArray());
+        NewTestMessage newParsedFromNew = NewTestMessage.parseFrom(newParsedFromJson.toByteArray());
+
+        Assert.assertEquals(newParsedFromOld, expected);
+        Assert.assertEquals(newParsedFromNew, expected);
+        Assert.assertEquals(newParsedFromJson, expected);	
+    }
+    
+    @Test(enabled = true, description = "https://github.com/bivas/protobuf-java-format/issues/24")
+    public void testReverseEscapeBytes() throws Exception {
+    	byte[] inBytes = {8, -110, -1, -1, -1, -1, -1, -1, -1, -1, 1};
+    	ByteString inByteString = ByteString.copyFrom(inBytes);
+    	String escaped = JsonFormat.escapeBytes(inByteString);
+    	ByteString outByteString = JsonFormat.unescapeBytes(escaped);
+    	byte[] outBytes = outByteString.toByteArray();
+    	
+    	Assert.assertTrue(Arrays.equals(inBytes, outBytes)); 
     }
 }

--- a/src/test/java/com/googlecode/protobuf/format/JsonJacksonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonJacksonFormatTest.java
@@ -4,10 +4,21 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.UnknownFieldSet;
+import com.googlecode.protobuf.format.issue23.Issue23;
+import com.googlecode.protobuf.format.issue23.Issue23.InnerTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.NewTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.OldTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.InnerTestMessage.InnerInnerTestMessage;
+import com.googlecode.protobuf.format.issue23.Issue23.NewTestMessage.UnknownGroup;
+
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
+
 import protobuf_unittest.UnittestProto;
 
 import java.io.StringWriter;
@@ -67,5 +78,95 @@ public class JsonJacksonFormatTest {
         assertThat(testAllTypesBuilder.getOptionalFixed32(), is((int) maxIntAsLong));
         assertThat(testAllTypesBuilder.getOptionalUint64(), is(maxLongAsBigInt.longValue()));
         assertThat(testAllTypesBuilder.getOptionalFixed64(), is(maxLongAsBigInt.longValue()));
+    }
+    
+    @Test(enabled=false, description = "https://github.com/bivas/protobuf-java-format/issues/23")
+    public void testIssue23Simple() throws Exception {    	
+    	JsonJacksonFormat jsonJacksonFormat =
+                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON);
+    	Issue23.MsgWithUnknownFields issue23Message = Issue23.MsgWithUnknownFields.newBuilder()
+                .setLeaf1("Hello")
+                .setLeaf2(23)
+                .addLeaf3(41)
+                .setUnknownFields(
+                        UnknownFieldSet.newBuilder()
+                                .addField(4, UnknownFieldSet.Field.newBuilder()
+                                        .addLengthDelimited(ByteString.copyFromUtf8("world"))
+                                        .build())
+                                .build())
+                .build();
+        String message = jsonJacksonFormat.printToString(issue23Message);        
+
+        Issue23.MsgWithUnknownFields.Builder issue23Builder = Issue23.MsgWithUnknownFields.newBuilder();
+        ExtensionRegistry extensionRegistry = ExtensionRegistry.newInstance();
+        Issue23.registerAllExtensions(extensionRegistry);
+        JsonParser jsonParser = JSON_FACTORY.createParser(message);
+        jsonJacksonFormat.merge(jsonParser, extensionRegistry, issue23Builder);
+        assertThat("No unknown field 4", issue23Builder.getUnknownFields().hasField(4));
+    }
+    
+    @Test(enabled=false, description = "https://github.com/bivas/protobuf-java-format/issues/23")
+    public void testIssue23Complex() throws Exception {
+    	// Create version of message with "unknown" fields
+        NewTestMessage expected = NewTestMessage.newBuilder()
+            .setKnownfield("hello")
+            .setUnknownfieldstring1("world")
+            .addUnknownfieldstring2("I")
+            .addUnknownfieldstring2("am")
+            .setUnknownfieldMessage(InnerTestMessage.newBuilder()
+                .setValue(30)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(1.2f))
+            )
+            .setUnknownfieldInt64(51232271120233L)
+            .setUnknownfieldInt32(6)
+            .setUnknownfieldFloat(2.3f)
+            .setUnknownfieldDouble(3.14d)
+            .addUnknownGroup(UnknownGroup.newBuilder()
+                .setName("hi")
+                .setIntvalue(23)
+                .setFloatvalue(5.2f)
+                .setLongvalue(44232993922327L))
+            .addUnknownfieldRepeatedMessage(InnerTestMessage.newBuilder()
+                .setValue(6)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(-1.3f))
+            )
+            .addUnknownfieldRepeatedMessage(InnerTestMessage.newBuilder()
+                .setValue(-110)
+                .setInnerMessage(InnerInnerTestMessage.newBuilder().setValue(0f))
+            )
+            .build();
+
+        // Parse this message into the old version of the proto
+        OldTestMessage parsedIntoOld = OldTestMessage.parseFrom(expected.toByteArray());
+
+        NewTestMessage newRightBackFromOld = NewTestMessage.parseFrom(parsedIntoOld.toByteArray());
+        Assert.assertEquals(newRightBackFromOld, expected);
+        
+        JsonJacksonFormat jsonJacksonFormat =
+                (JsonJacksonFormat) new FormatFactory().createFormatter(FormatFactory.Formatter.JSON_JACKSON);
+
+        // Convert to json
+        String oldJson = jsonJacksonFormat.printToString(parsedIntoOld);
+
+        // Parse back from json into new and old protos
+        OldTestMessage.Builder oldBuilder = OldTestMessage.newBuilder();
+        jsonJacksonFormat.merge(
+        	JSON_FACTORY.createParser(oldJson),
+            ExtensionRegistry.getEmptyRegistry(),
+            oldBuilder);
+        OldTestMessage oldParsedFromJson = oldBuilder.build();
+        NewTestMessage.Builder newBuilder = NewTestMessage.newBuilder();
+        jsonJacksonFormat.merge(
+            JSON_FACTORY.createParser(oldJson),
+            ExtensionRegistry.getEmptyRegistry(),
+            newBuilder);
+        NewTestMessage newParsedFromJson = newBuilder.build(); 
+
+        NewTestMessage newParsedFromOld = NewTestMessage.parseFrom(oldParsedFromJson.toByteArray());
+        NewTestMessage newParsedFromNew = NewTestMessage.parseFrom(newParsedFromJson.toByteArray());
+
+        Assert.assertEquals(newParsedFromOld, expected);
+        Assert.assertEquals(newParsedFromNew, expected);
+        Assert.assertEquals(newParsedFromJson, expected);	
     }
 }

--- a/src/test/resources/proto/issue23.proto
+++ b/src/test/resources/proto/issue23.proto
@@ -9,3 +9,33 @@ message MsgWithUnknownFields {
   optional int32 leaf2 = 2;
   repeated int32 leaf3 = 3;
 }
+
+message OldTestMessage {
+  optional string knownfield = 1;
+}
+
+message NewTestMessage {
+  optional string knownfield = 1;
+  optional string unknownfieldstring_1 = 2;
+  repeated string unknownfieldstring_2 = 3;
+  optional InnerTestMessage unknownfield_message = 4;
+  optional int64 unknownfield_int64 = 5;
+  optional int32 unknownfield_int32 = 6;
+  optional float unknownfield_float = 7;
+  optional double unknownfield_double = 8;
+  repeated group UnknownGroup = 9 {
+    optional string name = 1;
+    optional float floatvalue = 2;
+    optional int32 intvalue = 3;
+    optional int64 longvalue = 4;
+  }
+  repeated InnerTestMessage unknownfield_repeated_message = 10;
+}
+
+message InnerTestMessage {
+    message InnerInnerTestMessage {
+      optional float value =1;
+    }
+    optional int64 value = 1;
+    optional InnerInnerTestMessage inner_message = 2;
+}


### PR DESCRIPTION
For some reason, in the old PR, Github wasn't recognizing the force push I made to reduce the PR to one commit. So opening a new PR.

As specified in the title, this PR allows for unknown fields to be correctly handled in the json to proto conversion. Previously, only fields that were unknown at the time of json serialization (but known at deserialization time) were handled, and any others were skipped over.
