### PR TITLE
makes possible to override byte format

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/CouchDBFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/CouchDBFormat.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
+import com.googlecode.protobuf.format.bits.ByteSerializer;
 
 /**
  * Created by IntelliJ IDEA.
@@ -46,7 +47,7 @@ public class CouchDBFormat extends JsonFormat {
     public void merge(CharSequence input,
                              ExtensionRegistry extensionRegistry,
                              Message.Builder builder) throws ParseException {
-        Tokenizer tokenizer = new Tokenizer(input);
+        Tokenizer tokenizer = new Tokenizer(byteSerializer, input);
 
         // Based on the state machine @ http://json.org/
 
@@ -61,8 +62,8 @@ public class CouchDBFormat extends JsonFormat {
         /**
          * Construct a tokenizer that parses tokens from the given text.
          */
-        public Tokenizer(CharSequence text) {
-            super(text);
+        public Tokenizer(ByteSerializer byteSerializer, CharSequence text) {
+            super(byteSerializer, text);
         }
 
         @Override

--- a/src/main/java/com/googlecode/protobuf/format/InvalidEscapeSequence.java
+++ b/src/main/java/com/googlecode/protobuf/format/InvalidEscapeSequence.java
@@ -1,0 +1,45 @@
+package com.googlecode.protobuf.format;
+/*
+	Copyright (c) 2009, Orbitz World Wide
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+		* Redistributions of source code must retain the above copyright notice,
+		  this list of conditions and the following disclaimer.
+		* Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+		* Neither the name of the Orbitz World Wide nor the names of its contributors
+		  may be used to endorse or promote products derived from this software
+		  without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link com.googlecode.protobuf.format.bits.ByteSerializer#unescapeBytes} and {@link JsonFormat#unescapeText} when an
+ * invalid escape sequence is seen.
+ */
+public class InvalidEscapeSequence extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidEscapeSequence(String description) {
+        super(description);
+    }
+}

--- a/src/main/java/com/googlecode/protobuf/format/bits/Base64Serializer.java
+++ b/src/main/java/com/googlecode/protobuf/format/bits/Base64Serializer.java
@@ -1,0 +1,48 @@
+package com.googlecode.protobuf.format.bits;
+/*
+    Copyright (c) 2017, Lukas Karas <karas@avast.com>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+		* Redistributions of source code must retain the above copyright notice,
+		  this list of conditions and the following disclaimer.
+		* Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+		* Neither the name of the Orbitz World Wide nor the names of its contributors
+		  may be used to endorse or promote products derived from this software
+		  without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+import com.google.protobuf.ByteString;
+import com.googlecode.protobuf.format.InvalidEscapeSequence;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class Base64Serializer implements ByteSerializer {
+
+    @Override
+    public String escapeBytes(ByteString input) {
+        return DatatypeConverter.printBase64Binary(input.toByteArray());
+    }
+
+    @Override
+    public ByteString unescapeBytes(CharSequence input) throws InvalidEscapeSequence {
+        return ByteString.copyFrom(DatatypeConverter.parseBase64Binary(input.toString()));
+    }
+}

--- a/src/main/java/com/googlecode/protobuf/format/bits/ByteSerializer.java
+++ b/src/main/java/com/googlecode/protobuf/format/bits/ByteSerializer.java
@@ -1,0 +1,39 @@
+package com.googlecode.protobuf.format.bits;
+/*
+    Copyright (c) 2016, Lukas Karas <karas@avast.com>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+		* Redistributions of source code must retain the above copyright notice,
+		  this list of conditions and the following disclaimer.
+		* Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+		* Neither the name of the Orbitz World Wide nor the names of its contributors
+		  may be used to endorse or promote products derived from this software
+		  without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import com.google.protobuf.ByteString;
+import com.googlecode.protobuf.format.InvalidEscapeSequence;
+
+public interface ByteSerializer {
+
+    String escapeBytes(ByteString input);
+
+    ByteString unescapeBytes(CharSequence input) throws InvalidEscapeSequence;
+}

--- a/src/main/java/com/googlecode/protobuf/format/bits/DefaultByteSerializer.java
+++ b/src/main/java/com/googlecode/protobuf/format/bits/DefaultByteSerializer.java
@@ -1,0 +1,206 @@
+package com.googlecode.protobuf.format.bits;
+/*
+    Copyright (c) 2016, Lukas Karas <karas@avast.com>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+		* Redistributions of source code must retain the above copyright notice,
+		  this list of conditions and the following disclaimer.
+		* Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+		* Neither the name of the Orbitz World Wide nor the names of its contributors
+		  may be used to endorse or promote products derived from this software
+		  without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+import com.google.protobuf.ByteString;
+import com.googlecode.protobuf.format.InvalidEscapeSequence;
+
+import static com.googlecode.protobuf.format.util.TextUtils.*;
+
+public class DefaultByteSerializer implements ByteSerializer {
+
+    /**
+     * Escapes bytes in the format used in protocol buffer text format, which is the same as the
+     * format used for C string literals. All bytes that are not printable 7-bit ASCII characters
+     * are escaped, as well as backslash, single-quote, and double-quote characters. Characters for
+     * which no defined short-hand escape sequence is defined will be escaped using 3-digit octal
+     * sequences.
+     */
+    public String escapeBytes(ByteString input) {
+        StringBuilder builder = new StringBuilder(input.size());
+        for (int i = 0; i < input.size(); i++) {
+            byte b = input.byteAt(i);
+            switch (b) {
+                // Java does not recognize \a or \v, apparently.
+                case 0x07:
+                    builder.append("\\a");
+                    break;
+                case '\b':
+                    builder.append("\\b");
+                    break;
+                case '\f':
+                    builder.append("\\f");
+                    break;
+                case '\n':
+                    builder.append("\\n");
+                    break;
+                case '\r':
+                    builder.append("\\r");
+                    break;
+                case '\t':
+                    builder.append("\\t");
+                    break;
+                case 0x0b:
+                    builder.append("\\v");
+                    break;
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                case '\'':
+                    builder.append("\\\'");
+                    break;
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                default:
+                    if (b >= 0x20) {
+                        builder.append((char) b);
+                    } else {
+                        final String unicodeString = unicodeEscaped((char) b);
+                        builder.append(unicodeString);
+                    }
+                    break;
+            }
+        }
+        return builder.toString();
+    }
+
+    static String unicodeEscaped(char ch) {
+        if (ch < 0x10) {
+            return "\\u000" + Integer.toHexString(ch);
+        } else if (ch < 0x100) {
+            return "\\u00" + Integer.toHexString(ch);
+        } else if (ch < 0x1000) {
+            return "\\u0" + Integer.toHexString(ch);
+        }
+        return "\\u" + Integer.toHexString(ch);
+    }
+
+    /**
+     * Un-escape a byte sequence as escaped using
+     * {@link #escapeBytes(com.googlecode.protobuf.format.ByteString)}. Two-digit hex escapes (starting with
+     * "\x") are also recognized.
+     */
+    public ByteString unescapeBytes(CharSequence input) throws InvalidEscapeSequence {
+        byte[] result = new byte[input.length()];
+        int pos = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == '\\') {
+                if (i + 1 < input.length()) {
+                    ++i;
+                    c = input.charAt(i);
+                    if (isOctal(c)) {
+                        // Octal escape.
+                        int code = digitValue(c);
+                        if ((i + 1 < input.length()) && isOctal(input.charAt(i + 1))) {
+                            ++i;
+                            code = code * 8 + digitValue(input.charAt(i));
+                        }
+                        if ((i + 1 < input.length()) && isOctal(input.charAt(i + 1))) {
+                            ++i;
+                            code = code * 8 + digitValue(input.charAt(i));
+                        }
+                        result[pos++] = (byte) code;
+                    } else {
+                        switch (c) {
+                            case 'a':
+                                result[pos++] = 0x07;
+                                break;
+                            case 'b':
+                                result[pos++] = '\b';
+                                break;
+                            case 'f':
+                                result[pos++] = '\f';
+                                break;
+                            case 'n':
+                                result[pos++] = '\n';
+                                break;
+                            case 'r':
+                                result[pos++] = '\r';
+                                break;
+                            case 't':
+                                result[pos++] = '\t';
+                                break;
+                            case 'v':
+                                result[pos++] = 0x0b;
+                                break;
+                            case '\\':
+                                result[pos++] = '\\';
+                                break;
+                            case '\'':
+                                result[pos++] = '\'';
+                                break;
+                            case '"':
+                                result[pos++] = '\"';
+                                break;
+
+                            case 'x':
+                                // hex escape
+                                int code = 0;
+                                if ((i + 1 < input.length()) && isHex(input.charAt(i + 1))) {
+                                    ++i;
+                                    code = digitValue(input.charAt(i));
+                                } else {
+                                    throw new InvalidEscapeSequence("Invalid escape sequence: '\\x' with no digits");
+                                }
+                                if ((i + 1 < input.length()) && isHex(input.charAt(i + 1))) {
+                                    ++i;
+                                    code = code * 16 + digitValue(input.charAt(i));
+                                }
+                                result[pos++] = (byte) code;
+                                break;
+                            case 'u':
+                                // UTF8 escape
+                                code = (16 * 3 * digitValue(input.charAt(i + 1))) +
+                                        (16 * 2 * digitValue(input.charAt(i + 2))) +
+                                        (16 * digitValue(input.charAt(i + 3))) +
+                                        digitValue(input.charAt(i + 4));
+                                i = i + 4;
+                                result[pos++] = (byte) code;
+                                break;
+
+                            default:
+                                throw new InvalidEscapeSequence("Invalid escape sequence: '\\" + c
+                                        + "'");
+                        }
+                    }
+                } else {
+                    throw new InvalidEscapeSequence("Invalid escape sequence: '\\' at end of string.");
+                }
+            } else {
+                result[pos++] = (byte) c;
+            }
+        }
+
+        return ByteString.copyFrom(result, 0, pos);
+    }
+
+}

--- a/src/main/java/com/googlecode/protobuf/format/bits/HexByteSerializer.java
+++ b/src/main/java/com/googlecode/protobuf/format/bits/HexByteSerializer.java
@@ -1,0 +1,48 @@
+package com.googlecode.protobuf.format.bits;
+/*
+    Copyright (c) 2017, Lukas Karas <karas@avast.com>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+		* Redistributions of source code must retain the above copyright notice,
+		  this list of conditions and the following disclaimer.
+		* Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+		* Neither the name of the Orbitz World Wide nor the names of its contributors
+		  may be used to endorse or promote products derived from this software
+		  without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+import com.google.protobuf.ByteString;
+import com.googlecode.protobuf.format.InvalidEscapeSequence;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class HexByteSerializer implements ByteSerializer {
+
+    @Override
+    public String escapeBytes(ByteString input) {
+        return DatatypeConverter.printHexBinary(input.toByteArray());
+    }
+
+    @Override
+    public ByteString unescapeBytes(CharSequence input) throws InvalidEscapeSequence {
+        return ByteString.copyFrom(DatatypeConverter.parseHexBinary(input.toString()));
+    }
+}

--- a/src/test/resources/expectations/JsonFormatTest/test2_hex_bytes.json
+++ b/src/test/resources/expectations/JsonFormatTest/test2_hex_bytes.json
@@ -1,0 +1,1 @@
+{"optional_bytes": "48656C6C6F21"}

--- a/src/test/resources/expectations/JsonFormatTest/test3_base64_bytes.json
+++ b/src/test/resources/expectations/JsonFormatTest/test3_base64_bytes.json
@@ -1,0 +1,1 @@
+{"optional_bytes": "SGVsbG8h"}

--- a/src/test/resources/expectations/JsonFormatTest/test4_default_bytes.json
+++ b/src/test/resources/expectations/JsonFormatTest/test4_default_bytes.json
@@ -1,0 +1,1 @@
+{"optional_bytes": "Hello!"}


### PR DESCRIPTION
This PR ads ByteSerializer interface that enables override default byte array format. Then user can simply create hex-based or base64 serialization... https://github.com/bivas/protobuf-java-format/issues/32
