### PR TITLE
Null field from json deserialization fix

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/JsonJacksonFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JsonJacksonFormat.java
@@ -539,6 +539,9 @@ public class JsonJacksonFormat extends ProtobufFormatter {
         }
 
         JsonToken token = parser.getCurrentToken();
+        if (JsonToken.VALUE_NULL == token) {
+            return null;
+        }
 
         if (unknown) {
         	ByteString data = ByteString.copyFrom(parser.getBinaryValue());

--- a/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
+++ b/src/test/java/com/googlecode/protobuf/format/JsonFormatTest.java
@@ -16,6 +16,7 @@ import java.io.StringBufferInputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -74,5 +75,15 @@ public class JsonFormatTest {
         Issue23.registerAllExtensions(extensionRegistry);
         JSON_FORMATTER.merge(message, extensionRegistry, issue23Builder);
         assertThat("No unknown field 4", issue23Builder.getUnknownFields().hasField(4));
+    }
+
+    @Test
+    public void testDeserializeNullFieldFromJson() throws Exception {
+        UnittestProto.TestNullField.Builder builder = UnittestProto.TestNullField.newBuilder();
+        new JsonJacksonFormat().merge(JsonFormatTest.class.getResourceAsStream("/json_format_null_field_data.txt"), builder);
+
+        final UnittestProto.TestNullField actual = builder.build();
+        System.out.println(actual);
+        assertThat(actual, equalTo(UnittestProto.TestNullField.newBuilder().build()));
     }
 }

--- a/src/test/resources/json_format_null_field_data.txt
+++ b/src/test/resources/json_format_null_field_data.txt
@@ -1,0 +1,1 @@
+{"field" : null}

--- a/src/test/resources/proto/unittest.proto
+++ b/src/test/resources/proto/unittest.proto
@@ -629,3 +629,7 @@ service TestService {
 
 message BarRequest  {}
 message BarResponse {}
+
+message TestNullField {
+  optional TestNullField field = 1;
+}


### PR DESCRIPTION
At this moment deserialization from json differs in case when filed is omitted or equals to null.

`{}` deserializes to empty object when `{"field":null}` is deserialized to object with empty object for "field"

After this fix both json are deserialized to empty object
