### PR TITLE
Serialize enum with number by default

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/JsonFormat.java
@@ -204,9 +204,7 @@ public class JsonFormat extends AbstractCharBasedFormatter {
             }
 
             case ENUM: {
-                generator.print("\"");
-                generator.print(((EnumValueDescriptor) value).getName());
-                generator.print("\"");
+                generator.print(Integer.toString(((EnumValueDescriptor) value).getNumber()));
                 break;
             }
 

--- a/src/test/resources/expectations/JsonFormatTest/test1.json
+++ b/src/test/resources/expectations/JsonFormatTest/test1.json
@@ -1,1 +1,1 @@
-{"optional_foreign_enum": "FOREIGN_FOO","repeated_bool": [true,false,true]}
+{"optional_foreign_enum": 4,"repeated_bool": [true,false,true]}


### PR DESCRIPTION
In order to reduce the size of json payload, it should be better to send only the enum number instead of the value name.