### PR TITLE
Fix ProtobufFormatter.printToString

### DIFF
--- a/src/main/java/com/googlecode/protobuf/format/ProtobufFormatter.java
+++ b/src/main/java/com/googlecode/protobuf/format/ProtobufFormatter.java
@@ -88,7 +88,7 @@ public abstract class ProtobufFormatter {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             print(message, out, defaultCharset);
             out.flush();
-            return out.toString();
+            return out.toString(defaultCharset.name());
         } catch (IOException e) {
             throw new RuntimeException("Writing to a StringBuilder threw an IOException (should never happen).",
                                        e);
@@ -103,7 +103,7 @@ public abstract class ProtobufFormatter {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             print(fields, out, defaultCharset);
             out.flush();
-            return out.toString();
+            return out.toString(defaultCharset.name());
         } catch (IOException e) {
             throw new RuntimeException("Writing to a StringBuilder threw an IOException (should never happen).",
                                        e);


### PR DESCRIPTION
ProtobufFormatter.printToString method current does not consider the defaultCharset when convert the ByteArrayOutputStream to String