### PR TITLE
Fix #51 #52: Commons Text StringEscapeUtils for HTML and XML.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,18 @@
 		<fasterxml.version>2.5.0</fasterxml.version>
 	</properties>
 	<dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.3</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>2.5.0</version>
+            <scope>provided</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,18 +59,18 @@
 		<fasterxml.version>2.5.0</fasterxml.version>
 	</properties>
 	<dependencies>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>2.5.0</version>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>2.5.0</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>

--- a/src/main/java/com/googlecode/protobuf/format/HtmlFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/HtmlFormat.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
@@ -493,7 +495,7 @@ public final class HtmlFormat extends AbstractCharBasedFormatter {
      * 3-digit octal escape. Yes, it's weird.
      */
     static String escapeText(String input) {
-        return escapeBytes(ByteString.copyFromUtf8(input));
+        return StringEscapeUtils.escapeHtml4(input);
     }
 
     /**
@@ -501,7 +503,7 @@ public final class HtmlFormat extends AbstractCharBasedFormatter {
      * (starting with "\x") are also recognized.
      */
     static String unescapeText(String input) throws InvalidEscapeSequence {
-        return unescapeBytes(input).toStringUtf8();
+        return StringEscapeUtils.unescapeHtml4(input);
     }
 
 

--- a/src/main/java/com/googlecode/protobuf/format/XmlFormat.java
+++ b/src/main/java/com/googlecode/protobuf/format/XmlFormat.java
@@ -36,6 +36,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.text.StringEscapeUtils;
+
 import java.nio.CharBuffer;
 
 import com.google.protobuf.ByteString;
@@ -1060,7 +1063,7 @@ public final class XmlFormat extends AbstractCharBasedFormatter {
      * 3-digit octal escape. Yes, it's weird.
      */
     static String escapeText(String input) {
-        return escapeBytes(ByteString.copyFromUtf8(input));
+        return StringEscapeUtils.escapeXml11(input);
     }
 
     /**
@@ -1068,7 +1071,7 @@ public final class XmlFormat extends AbstractCharBasedFormatter {
      * (starting with "\x") are also recognized.
      */
     static String unescapeText(String input) throws InvalidEscapeSequence {
-        return unescapeBytes(input).toStringUtf8();
+        return StringEscapeUtils.unescapeXml(input);
     }
 
 


### PR DESCRIPTION
Not sure if you will accept this PR but this makes the escaping way more bulletproof than the current version for XML and HTML.